### PR TITLE
Patchfix: Esconde proposição sem votos no endpoint da adesão

### DIFF
--- a/landing/candidate/adhesion.py
+++ b/landing/candidate/adhesion.py
@@ -100,6 +100,9 @@ class CandidateAdhesion(ABC):
 
         adesao["total_com_votos"] = total_calculadas
 
+        if adesao["total_com_votos"] == 0:
+            return None
+
         # quanto menos o parlamentar divergir do lider, maior é a sua adesão
         adesao["adhesion"] = (
             (total_calculadas - adesao["different"]) / total_calculadas


### PR DESCRIPTION
## Descrição do problema
Patchfix: Proposições sem votações não são mostradas no endpoint da adesão, mas quando uma proposição tem votações e as votações não tem votos(na api da câmara) essa proposição está sendo mostrada com adesão "0". Esse é o caso da "Dia dos Povos Indígenas", id=2224662.

Ela possui votações: https://dadosabertos.camara.leg.br/api/v2/proposicoes/2224662/votacoes?ordem=DESC&ordenarPor=dataHoraRegistro
Houveram 4 votações, porem não constam nenhum voto em todas as 4 votações.
- https://dadosabertos.camara.leg.br/api/v2/votacoes/2224662-69/votos
- https://dadosabertos.camara.leg.br/api/v2/votacoes/2224662-55/votos
- https://dadosabertos.camara.leg.br/api/v2/votacoes/2224662-36/votos
- https://dadosabertos.camara.leg.br/api/v2/votacoes/2224662-21/votos

## O que o PR faz
Esse PR faz com que proposições sem votos não sejam retornadas no endpoint da adesão.
