### PR TITLE
Fix accentuation and board opening

### DIFF
--- a/landing/candidate/models.py
+++ b/landing/candidate/models.py
@@ -1,8 +1,9 @@
 from django.db import models
 from django.db.models.signals import post_save
-from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.core.paginator import EmptyPage, Paginator
 from django.dispatch import receiver
-from django.template.defaultfilters import slugify
+
+import unidecode 
 
 from wagtailmetadata.models import MetadataPageMixin
 from wagtail.core.models import Page
@@ -219,12 +220,17 @@ class CandidateIndexPage(MetadataPageMixin, Page):
         reelections = []
 
         params_functions = {
-            'name': lambda queryset, value: queryset.filter(title__icontains=value),
             'uf[]': lambda queryset, values: queryset.filter(election_state__in=values),
             'party[]': lambda queryset, values: queryset.filter(party__in=values),
             'sortby': lambda queryset, value: queryset.order_by('-title') if value == 'descending' else queryset,
             'id_autor': lambda queryset, value: queryset.filter(id_autor__isnull=value),
         }
+
+        def name_filtering(search, target):
+            simplify = lambda word: unidecode.unidecode(word.lower()) # Remove accents and uppercase chars
+            target = simplify(target)
+            search = simplify(search)
+            return search in target
 
         request_items = dict(request.GET)
         for param, value in list(request_items.items()):
@@ -236,6 +242,9 @@ class CandidateIndexPage(MetadataPageMixin, Page):
                 reelections.append(election_dict[param])
             if param not in ['uf[]', 'party[]']:
                 value = value[0]
+            if param == 'name':
+                to_keep = [candidate.id_autor for candidate in queryset if name_filtering(value, candidate.title)]
+                queryset = queryset.filter(id_autor__in=to_keep)
             if value and param in params_functions:
                 pass
                 queryset = params_functions[param](queryset, value)

--- a/landing/candidate/templates/candidate/candidate_index_page.html
+++ b/landing/candidate/templates/candidate/candidate_index_page.html
@@ -36,7 +36,7 @@
         <input type="hidden" id='page' name='page' value="1">
         <div class="query__select">
             <div id='uf' class="input-board">
-                <button>UF <i class="fas fa-caret-down"></i></button>
+                <button type="button">UF <i class="fas fa-caret-down"></i></button>
                 <div class="input-board__selector">
                     <p>Mostrar candidatos do(s) estado(s):</p>
                     <div class="input-board__content">
@@ -50,7 +50,7 @@
                 </div>
                 </div>
                 <div id='party' class="input-board">
-                    <button>Partido <i class="fas fa-caret-down"></i></button>
+                    <button type="button">Partido <i class="fas fa-caret-down"></i></button>
                     <div class="input-board__selector large">
                         <p>Mostrar candidatos do(s) partido(s):</p>
                         <div class="input-board__content">

--- a/landing/landing/static/js/candidate/candidate_list.js
+++ b/landing/landing/static/js/candidate/candidate_list.js
@@ -84,7 +84,7 @@ inputs.forEach(obj => obj.addEventListener('change', (e) => {
     getCandidatesList();
 }));
 
-nameInput.addEventListener('keypress', () => getCandidatesList());
+nameInput.addEventListener('input', () => getCandidatesList());
 
 states.forEach(state => state.addEventListener('click', () => {
     let input = Array.from(inputs)


### PR DESCRIPTION
## Descrição
Esse PR corrige o bug do quadro de UFs, em que toda vez que um usuário pressiona enter no campo de nome, o campo de Unidades Federativas é aberto. Esse problema foi corrigido aplicando o tipo _button_ para os botões dentro da tag form. Foi implementada também a insensibilidade a acentos na busca por nomes.

## Issue
#159 