### PR TITLE
Fix filter reelection issue

### DIFF
--- a/landing/candidate/models.py
+++ b/landing/candidate/models.py
@@ -247,8 +247,8 @@ class CandidateIndexPage(MetadataPageMixin, Page):
             if param not in ['uf[]', 'party[]']:
                 value = value[0]
             if param == 'name':
-                to_keep = [candidate.id_autor for candidate in queryset if name_filtering(value, candidate.title)]
-                queryset = queryset.filter(id_autor__in=to_keep)
+                to_keep = [candidate.title for candidate in queryset if name_filtering(value, candidate.title)]
+                queryset = queryset.filter(title__in=to_keep)
             if value and param in params_functions:
                 pass
                 queryset = params_functions[param](queryset, value)


### PR DESCRIPTION
## Descrição
Corrige o problema dos não- candidatos a reeleição que estavam sumidos após uma recente atualização. O filtro selecionava os indicados pelo id_author, o que tornava impossível encontrar os candidatos que não vão se reeleger. 

## Issue 
#167